### PR TITLE
Fix two parsing problems

### DIFF
--- a/src/main/java/net/badata/protobuf/converter/utils/FieldUtils.java
+++ b/src/main/java/net/badata/protobuf/converter/utils/FieldUtils.java
@@ -32,6 +32,7 @@ import java.util.Collection;
  */
 public final class FieldUtils {
 
+	private static final String HASSER_PREFIX = "has";
 	private static final String GETTER_PREFIX = "get";
 	private static final String SETTER_PREFIX = "set";
 	private static final String BOOLEAN_GETTER_PREFIX = "is";
@@ -78,6 +79,19 @@ public final class FieldUtils {
 	 */
 	public static boolean isCollectionType(final Class<?> type) {
 		return Collection.class.isAssignableFrom(type);
+	}
+
+	/**
+	 * Create protobuf getter name for domain field.
+	 *
+	 * @param fieldResolver Domain object field resolver.
+	 * @return Protobuf field getter name.
+	 */
+	public static String createProtobufHasserName(final FieldResolver fieldResolver) {
+		if (isCollectionType(fieldResolver.getProtobufType())) {
+			return null;
+		}
+		return StringUtils.createMethodName(HASSER_PREFIX, fieldResolver.getProtobufName());
 	}
 
 	/**

--- a/src/test/java/net/badata/protobuf/converter/ConverterTest.java
+++ b/src/test/java/net/badata/protobuf/converter/ConverterTest.java
@@ -57,6 +57,7 @@ public class ConverterTest {
 				.addComplexListValue(ConverterProto.PrimitiveTest.newBuilder().setIntValue(1001))
 				.addComplexSetValue(ConverterProto.PrimitiveTest.newBuilder().setIntValue(1002))
 				.setBytesValue(ByteString.copyFrom(new byte[]{ 0, 1, 3, 7 }))
+				.setRecursiveValue(ConverterProto.ConverterTest.newBuilder().setIntValue(1))
 				.build();
 	}
 
@@ -95,6 +96,10 @@ public class ConverterTest {
 		testDomain.setComplexNullableCollectionValue(null);
 
 		testDomain.setBytesValue(ByteString.copyFrom(new byte[]{ 0, 1, 3, 7 }));
+
+		ConverterDomain.Test nestedValue = new ConverterDomain.Test();
+		nestedValue.setIntValue(1);
+		testDomain.setRecursiveValue(nestedValue);
 	}
 
 	private void createIgnoredFieldsMap() {
@@ -151,7 +156,8 @@ public class ConverterTest {
 
 		Assert.assertTrue(result.getComplexNullableCollectionValue().isEmpty());
 
-		Assert.assertEquals(testProtobuf.getBytesValue(), testDomain.getBytesValue());
+		Assert.assertEquals(testProtobuf.getBytesValue(), result.getBytesValue());
+		Assert.assertEquals((Object) testProtobuf.getRecursiveValue().getIntValue(), result.getRecursiveValue().getIntValue());
 	}
 
 	@Test
@@ -208,6 +214,7 @@ public class ConverterTest {
 				result.getComplexSetValue(0).getIntValue());
 
 		Assert.assertTrue(result.getComplexNullableCollectionValueList().isEmpty());
+		Assert.assertEquals((Object) testDomain.getRecursiveValue().getIntValue(), result.getRecursiveValue().getIntValue());
 	}
 
 	@Test

--- a/src/test/java/net/badata/protobuf/converter/ConverterTest.java
+++ b/src/test/java/net/badata/protobuf/converter/ConverterTest.java
@@ -1,5 +1,6 @@
 package net.badata.protobuf.converter;
 
+import com.google.protobuf.ByteString;
 import net.badata.protobuf.converter.domain.ConverterDomain;
 import net.badata.protobuf.converter.proto.ConverterProto;
 import org.junit.Assert;
@@ -55,6 +56,7 @@ public class ConverterTest {
 				.addStringListValue("10")
 				.addComplexListValue(ConverterProto.PrimitiveTest.newBuilder().setIntValue(1001))
 				.addComplexSetValue(ConverterProto.PrimitiveTest.newBuilder().setIntValue(1002))
+				.setBytesValue(ByteString.copyFrom(new byte[]{ 0, 1, 3, 7 }))
 				.build();
 	}
 
@@ -91,6 +93,8 @@ public class ConverterTest {
 		primitiveTestItem.setIntValue(-1002);
 		testDomain.setComplexSetValue(new HashSet<ConverterDomain.PrimitiveTest>(Arrays.asList(primitiveTestSItem)));
 		testDomain.setComplexNullableCollectionValue(null);
+
+		testDomain.setBytesValue(ByteString.copyFrom(new byte[]{ 0, 1, 3, 7 }));
 	}
 
 	private void createIgnoredFieldsMap() {
@@ -146,6 +150,8 @@ public class ConverterTest {
 				result.getComplexSetValue().iterator().next().getIntValue());
 
 		Assert.assertTrue(result.getComplexNullableCollectionValue().isEmpty());
+
+		Assert.assertEquals(testProtobuf.getBytesValue(), testDomain.getBytesValue());
 	}
 
 	@Test

--- a/src/test/java/net/badata/protobuf/converter/domain/ConverterDomain.java
+++ b/src/test/java/net/badata/protobuf/converter/domain/ConverterDomain.java
@@ -58,6 +58,8 @@ public class ConverterDomain {
 		private List<PrimitiveTest> complexNullableCollectionValue;
 		@ProtoField
 		private ByteString bytesValue;
+		@ProtoField
+		private Test recursiveValue;
 
 
 		public Long getLongValue() {
@@ -171,6 +173,14 @@ public class ConverterDomain {
 
 		public void setBytesValue(ByteString bytesValue) {
 			this.bytesValue = bytesValue;
+		}
+
+		public Test getRecursiveValue() {
+			return recursiveValue;
+		}
+
+		public void setRecursiveValue(Test recursiveValue) {
+			this.recursiveValue = recursiveValue;
 		}
 	}
 

--- a/src/test/java/net/badata/protobuf/converter/domain/ConverterDomain.java
+++ b/src/test/java/net/badata/protobuf/converter/domain/ConverterDomain.java
@@ -1,5 +1,6 @@
 package net.badata.protobuf.converter.domain;
 
+import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
 import net.badata.protobuf.converter.annotation.ProtoClass;
 import net.badata.protobuf.converter.annotation.ProtoField;
@@ -55,6 +56,8 @@ public class ConverterDomain {
 		private Set<PrimitiveTest> complexSetValue;
 		@ProtoField
 		private List<PrimitiveTest> complexNullableCollectionValue;
+		@ProtoField
+		private ByteString bytesValue;
 
 
 		public Long getLongValue() {
@@ -160,6 +163,14 @@ public class ConverterDomain {
 
 		public void setComplexNullableCollectionValue(final List<PrimitiveTest> complexNullableCollectionValue) {
 			this.complexNullableCollectionValue = complexNullableCollectionValue;
+		}
+
+		public ByteString getBytesValue() {
+			return bytesValue;
+		}
+
+		public void setBytesValue(ByteString bytesValue) {
+			this.bytesValue = bytesValue;
 		}
 	}
 

--- a/src/test/java/net/badata/protobuf/converter/proto/ConverterProto.java
+++ b/src/test/java/net/badata/protobuf/converter/proto/ConverterProto.java
@@ -2250,6 +2250,11 @@ public final class ConverterProto {
      */
     net.badata.protobuf.converter.proto.ConverterProto.PrimitiveTestOrBuilder getComplexNullableCollectionValueOrBuilder(
         int index);
+
+    /**
+     * <code>optional bytes bytesValue = 14;</code>
+     */
+    com.google.protobuf.ByteString getBytesValue();
   }
   /**
    * Protobuf type {@code net.badata.protobuf.converter.proto.ConverterTest}
@@ -2273,6 +2278,7 @@ public final class ConverterProto {
       complexListValue_ = java.util.Collections.emptyList();
       complexSetValue_ = java.util.Collections.emptyList();
       complexNullableCollectionValue_ = java.util.Collections.emptyList();
+      bytesValue_ = com.google.protobuf.ByteString.EMPTY;
     }
 
     @java.lang.Override
@@ -2400,6 +2406,11 @@ public final class ConverterProto {
                 mutable_bitField0_ |= 0x00001000;
               }
               complexNullableCollectionValue_.add(input.readMessage(net.badata.protobuf.converter.proto.ConverterProto.PrimitiveTest.parser(), extensionRegistry));
+              break;
+            }
+            case 114: {
+
+              bytesValue_ = input.readBytes();
               break;
             }
           }
@@ -2715,6 +2726,15 @@ public final class ConverterProto {
       return complexNullableCollectionValue_.get(index);
     }
 
+    public static final int BYTESVALUE_FIELD_NUMBER = 14;
+    private com.google.protobuf.ByteString bytesValue_;
+    /**
+     * <code>optional bytes bytesValue = 14;</code>
+     */
+    public com.google.protobuf.ByteString getBytesValue() {
+      return bytesValue_;
+    }
+
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
@@ -2765,6 +2785,9 @@ public final class ConverterProto {
       }
       for (int i = 0; i < complexNullableCollectionValue_.size(); i++) {
         output.writeMessage(13, complexNullableCollectionValue_.get(i));
+      }
+      if (!bytesValue_.isEmpty()) {
+        output.writeBytes(14, bytesValue_);
       }
     }
 
@@ -2827,6 +2850,10 @@ public final class ConverterProto {
       for (int i = 0; i < complexNullableCollectionValue_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(13, complexNullableCollectionValue_.get(i));
+      }
+      if (!bytesValue_.isEmpty()) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(14, bytesValue_);
       }
       memoizedSize = size;
       return size;
@@ -2992,6 +3019,8 @@ public final class ConverterProto {
         } else {
           complexNullableCollectionValueBuilder_.clear();
         }
+        bytesValue_ = com.google.protobuf.ByteString.EMPTY;
+
         return this;
       }
 
@@ -3069,6 +3098,7 @@ public final class ConverterProto {
         } else {
           result.complexNullableCollectionValue_ = complexNullableCollectionValueBuilder_.build();
         }
+        result.bytesValue_ = bytesValue_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -3200,6 +3230,9 @@ public final class ConverterProto {
               complexNullableCollectionValueBuilder_.addAllMessages(other.complexNullableCollectionValue_);
             }
           }
+        }
+        if (other.getBytesValue() != com.google.protobuf.ByteString.EMPTY) {
+          setBytesValue(other.getBytesValue());
         }
         onChanged();
         return this;
@@ -4591,6 +4624,35 @@ public final class ConverterProto {
         }
         return complexNullableCollectionValueBuilder_;
       }
+
+      private com.google.protobuf.ByteString bytesValue_ = com.google.protobuf.ByteString.EMPTY;
+      /**
+       * <code>optional bytes bytesValue = 14;</code>
+       */
+      public com.google.protobuf.ByteString getBytesValue() {
+        return bytesValue_;
+      }
+      /**
+       * <code>optional bytes bytesValue = 14;</code>
+       */
+      public Builder setBytesValue(com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        bytesValue_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bytes bytesValue = 14;</code>
+       */
+      public Builder clearBytesValue() {
+        
+        bytesValue_ = getDefaultInstance().getBytesValue();
+        onChanged();
+        return this;
+      }
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return this;
@@ -4688,7 +4750,7 @@ public final class ConverterProto {
       "\022\022\n\nnullString\030\001 \001(\t\022\036\n\026customInspection" +
       "String\030\002 \001(\t\022M\n\021defaultPrimitives\030\003 \001(\0132" +
       "2.net.badata.protobuf.converter.proto.Pr",
-      "imitiveTest\"\213\005\n\rConverterTest\022\020\n\010intValu" +
+      "imitiveTest\"\237\005\n\rConverterTest\022\020\n\010intValu" +
       "e\030\001 \001(\005\022\021\n\tlongValue\030\002 \001(\003\022\022\n\nfloatValue" +
       "\030\003 \001(\002\022\023\n\013doubleValue\030\004 \001(\001\022\024\n\014booleanVa" +
       "lue\030\005 \001(\010\022\023\n\013stringValue\030\006 \001(\t\022J\n\016primit" +
@@ -4704,9 +4766,9 @@ public final class ConverterProto {
       "\01322.net.badata.protobuf.converter.proto." +
       "PrimitiveTest\022Z\n\036complexNullableCollecti" +
       "onValue\030\r \003(\01322.net.badata.protobuf.conv" +
-      "erter.proto.PrimitiveTestB5\n#net.badata." +
-      "protobuf.converter.protoB\016ConverterProto" +
-      "b\006proto3"
+      "erter.proto.PrimitiveTest\022\022\n\nbytesValue\030" +
+      "\016 \001(\014B5\n#net.badata.protobuf.converter.p" +
+      "rotoB\016ConverterProtob\006proto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -4743,7 +4805,7 @@ public final class ConverterProto {
     internal_static_net_badata_protobuf_converter_proto_ConverterTest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_net_badata_protobuf_converter_proto_ConverterTest_descriptor,
-        new java.lang.String[] { "IntValue", "LongValue", "FloatValue", "DoubleValue", "BooleanValue", "StringValue", "PrimitiveValue", "FieldConversionValue", "NullDefaultValue", "StringListValue", "ComplexListValue", "ComplexSetValue", "ComplexNullableCollectionValue", });
+        new java.lang.String[] { "IntValue", "LongValue", "FloatValue", "DoubleValue", "BooleanValue", "StringValue", "PrimitiveValue", "FieldConversionValue", "NullDefaultValue", "StringListValue", "ComplexListValue", "ComplexSetValue", "ComplexNullableCollectionValue", "BytesValue", });
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/src/test/java/net/badata/protobuf/converter/proto/ConverterProto.java
+++ b/src/test/java/net/badata/protobuf/converter/proto/ConverterProto.java
@@ -2255,6 +2255,19 @@ public final class ConverterProto {
      * <code>optional bytes bytesValue = 14;</code>
      */
     com.google.protobuf.ByteString getBytesValue();
+
+    /**
+     * <code>optional .net.badata.protobuf.converter.proto.ConverterTest recursiveValue = 15;</code>
+     */
+    boolean hasRecursiveValue();
+    /**
+     * <code>optional .net.badata.protobuf.converter.proto.ConverterTest recursiveValue = 15;</code>
+     */
+    net.badata.protobuf.converter.proto.ConverterProto.ConverterTest getRecursiveValue();
+    /**
+     * <code>optional .net.badata.protobuf.converter.proto.ConverterTest recursiveValue = 15;</code>
+     */
+    net.badata.protobuf.converter.proto.ConverterProto.ConverterTestOrBuilder getRecursiveValueOrBuilder();
   }
   /**
    * Protobuf type {@code net.badata.protobuf.converter.proto.ConverterTest}
@@ -2411,6 +2424,19 @@ public final class ConverterProto {
             case 114: {
 
               bytesValue_ = input.readBytes();
+              break;
+            }
+            case 122: {
+              net.badata.protobuf.converter.proto.ConverterProto.ConverterTest.Builder subBuilder = null;
+              if (recursiveValue_ != null) {
+                subBuilder = recursiveValue_.toBuilder();
+              }
+              recursiveValue_ = input.readMessage(net.badata.protobuf.converter.proto.ConverterProto.ConverterTest.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(recursiveValue_);
+                recursiveValue_ = subBuilder.buildPartial();
+              }
+
               break;
             }
           }
@@ -2735,6 +2761,27 @@ public final class ConverterProto {
       return bytesValue_;
     }
 
+    public static final int RECURSIVEVALUE_FIELD_NUMBER = 15;
+    private net.badata.protobuf.converter.proto.ConverterProto.ConverterTest recursiveValue_;
+    /**
+     * <code>optional .net.badata.protobuf.converter.proto.ConverterTest recursiveValue = 15;</code>
+     */
+    public boolean hasRecursiveValue() {
+      return recursiveValue_ != null;
+    }
+    /**
+     * <code>optional .net.badata.protobuf.converter.proto.ConverterTest recursiveValue = 15;</code>
+     */
+    public net.badata.protobuf.converter.proto.ConverterProto.ConverterTest getRecursiveValue() {
+      return recursiveValue_ == null ? net.badata.protobuf.converter.proto.ConverterProto.ConverterTest.getDefaultInstance() : recursiveValue_;
+    }
+    /**
+     * <code>optional .net.badata.protobuf.converter.proto.ConverterTest recursiveValue = 15;</code>
+     */
+    public net.badata.protobuf.converter.proto.ConverterProto.ConverterTestOrBuilder getRecursiveValueOrBuilder() {
+      return getRecursiveValue();
+    }
+
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
@@ -2788,6 +2835,9 @@ public final class ConverterProto {
       }
       if (!bytesValue_.isEmpty()) {
         output.writeBytes(14, bytesValue_);
+      }
+      if (recursiveValue_ != null) {
+        output.writeMessage(15, getRecursiveValue());
       }
     }
 
@@ -2854,6 +2904,10 @@ public final class ConverterProto {
       if (!bytesValue_.isEmpty()) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(14, bytesValue_);
+      }
+      if (recursiveValue_ != null) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(15, getRecursiveValue());
       }
       memoizedSize = size;
       return size;
@@ -3021,6 +3075,12 @@ public final class ConverterProto {
         }
         bytesValue_ = com.google.protobuf.ByteString.EMPTY;
 
+        if (recursiveValueBuilder_ == null) {
+          recursiveValue_ = null;
+        } else {
+          recursiveValue_ = null;
+          recursiveValueBuilder_ = null;
+        }
         return this;
       }
 
@@ -3099,6 +3159,11 @@ public final class ConverterProto {
           result.complexNullableCollectionValue_ = complexNullableCollectionValueBuilder_.build();
         }
         result.bytesValue_ = bytesValue_;
+        if (recursiveValueBuilder_ == null) {
+          result.recursiveValue_ = recursiveValue_;
+        } else {
+          result.recursiveValue_ = recursiveValueBuilder_.build();
+        }
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -3233,6 +3298,9 @@ public final class ConverterProto {
         }
         if (other.getBytesValue() != com.google.protobuf.ByteString.EMPTY) {
           setBytesValue(other.getBytesValue());
+        }
+        if (other.hasRecursiveValue()) {
+          mergeRecursiveValue(other.getRecursiveValue());
         }
         onChanged();
         return this;
@@ -4653,6 +4721,123 @@ public final class ConverterProto {
         onChanged();
         return this;
       }
+
+      private net.badata.protobuf.converter.proto.ConverterProto.ConverterTest recursiveValue_ = null;
+      private com.google.protobuf.SingleFieldBuilder<
+          net.badata.protobuf.converter.proto.ConverterProto.ConverterTest, net.badata.protobuf.converter.proto.ConverterProto.ConverterTest.Builder, net.badata.protobuf.converter.proto.ConverterProto.ConverterTestOrBuilder> recursiveValueBuilder_;
+      /**
+       * <code>optional .net.badata.protobuf.converter.proto.ConverterTest recursiveValue = 15;</code>
+       */
+      public boolean hasRecursiveValue() {
+        return recursiveValueBuilder_ != null || recursiveValue_ != null;
+      }
+      /**
+       * <code>optional .net.badata.protobuf.converter.proto.ConverterTest recursiveValue = 15;</code>
+       */
+      public net.badata.protobuf.converter.proto.ConverterProto.ConverterTest getRecursiveValue() {
+        if (recursiveValueBuilder_ == null) {
+          return recursiveValue_ == null ? net.badata.protobuf.converter.proto.ConverterProto.ConverterTest.getDefaultInstance() : recursiveValue_;
+        } else {
+          return recursiveValueBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>optional .net.badata.protobuf.converter.proto.ConverterTest recursiveValue = 15;</code>
+       */
+      public Builder setRecursiveValue(net.badata.protobuf.converter.proto.ConverterProto.ConverterTest value) {
+        if (recursiveValueBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          recursiveValue_ = value;
+          onChanged();
+        } else {
+          recursiveValueBuilder_.setMessage(value);
+        }
+
+        return this;
+      }
+      /**
+       * <code>optional .net.badata.protobuf.converter.proto.ConverterTest recursiveValue = 15;</code>
+       */
+      public Builder setRecursiveValue(
+          net.badata.protobuf.converter.proto.ConverterProto.ConverterTest.Builder builderForValue) {
+        if (recursiveValueBuilder_ == null) {
+          recursiveValue_ = builderForValue.build();
+          onChanged();
+        } else {
+          recursiveValueBuilder_.setMessage(builderForValue.build());
+        }
+
+        return this;
+      }
+      /**
+       * <code>optional .net.badata.protobuf.converter.proto.ConverterTest recursiveValue = 15;</code>
+       */
+      public Builder mergeRecursiveValue(net.badata.protobuf.converter.proto.ConverterProto.ConverterTest value) {
+        if (recursiveValueBuilder_ == null) {
+          if (recursiveValue_ != null) {
+            recursiveValue_ =
+              net.badata.protobuf.converter.proto.ConverterProto.ConverterTest.newBuilder(recursiveValue_).mergeFrom(value).buildPartial();
+          } else {
+            recursiveValue_ = value;
+          }
+          onChanged();
+        } else {
+          recursiveValueBuilder_.mergeFrom(value);
+        }
+
+        return this;
+      }
+      /**
+       * <code>optional .net.badata.protobuf.converter.proto.ConverterTest recursiveValue = 15;</code>
+       */
+      public Builder clearRecursiveValue() {
+        if (recursiveValueBuilder_ == null) {
+          recursiveValue_ = null;
+          onChanged();
+        } else {
+          recursiveValue_ = null;
+          recursiveValueBuilder_ = null;
+        }
+
+        return this;
+      }
+      /**
+       * <code>optional .net.badata.protobuf.converter.proto.ConverterTest recursiveValue = 15;</code>
+       */
+      public net.badata.protobuf.converter.proto.ConverterProto.ConverterTest.Builder getRecursiveValueBuilder() {
+        
+        onChanged();
+        return getRecursiveValueFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .net.badata.protobuf.converter.proto.ConverterTest recursiveValue = 15;</code>
+       */
+      public net.badata.protobuf.converter.proto.ConverterProto.ConverterTestOrBuilder getRecursiveValueOrBuilder() {
+        if (recursiveValueBuilder_ != null) {
+          return recursiveValueBuilder_.getMessageOrBuilder();
+        } else {
+          return recursiveValue_ == null ?
+              net.badata.protobuf.converter.proto.ConverterProto.ConverterTest.getDefaultInstance() : recursiveValue_;
+        }
+      }
+      /**
+       * <code>optional .net.badata.protobuf.converter.proto.ConverterTest recursiveValue = 15;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+          net.badata.protobuf.converter.proto.ConverterProto.ConverterTest, net.badata.protobuf.converter.proto.ConverterProto.ConverterTest.Builder, net.badata.protobuf.converter.proto.ConverterProto.ConverterTestOrBuilder> 
+          getRecursiveValueFieldBuilder() {
+        if (recursiveValueBuilder_ == null) {
+          recursiveValueBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              net.badata.protobuf.converter.proto.ConverterProto.ConverterTest, net.badata.protobuf.converter.proto.ConverterProto.ConverterTest.Builder, net.badata.protobuf.converter.proto.ConverterProto.ConverterTestOrBuilder>(
+                  getRecursiveValue(),
+                  getParentForChildren(),
+                  isClean());
+          recursiveValue_ = null;
+        }
+        return recursiveValueBuilder_;
+      }
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return this;
@@ -4750,7 +4935,7 @@ public final class ConverterProto {
       "\022\022\n\nnullString\030\001 \001(\t\022\036\n\026customInspection" +
       "String\030\002 \001(\t\022M\n\021defaultPrimitives\030\003 \001(\0132" +
       "2.net.badata.protobuf.converter.proto.Pr",
-      "imitiveTest\"\237\005\n\rConverterTest\022\020\n\010intValu" +
+      "imitiveTest\"\353\005\n\rConverterTest\022\020\n\010intValu" +
       "e\030\001 \001(\005\022\021\n\tlongValue\030\002 \001(\003\022\022\n\nfloatValue" +
       "\030\003 \001(\002\022\023\n\013doubleValue\030\004 \001(\001\022\024\n\014booleanVa" +
       "lue\030\005 \001(\010\022\023\n\013stringValue\030\006 \001(\t\022J\n\016primit" +
@@ -4767,8 +4952,10 @@ public final class ConverterProto {
       "PrimitiveTest\022Z\n\036complexNullableCollecti" +
       "onValue\030\r \003(\01322.net.badata.protobuf.conv" +
       "erter.proto.PrimitiveTest\022\022\n\nbytesValue\030" +
-      "\016 \001(\014B5\n#net.badata.protobuf.converter.p" +
-      "rotoB\016ConverterProtob\006proto3"
+      "\016 \001(\014\022J\n\016recursiveValue\030\017 \001(\01322.net.bada" +
+      "ta.protobuf.converter.proto.ConverterTes" +
+      "tB5\n#net.badata.protobuf.converter.proto",
+      "B\016ConverterProtob\006proto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -4805,7 +4992,7 @@ public final class ConverterProto {
     internal_static_net_badata_protobuf_converter_proto_ConverterTest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_net_badata_protobuf_converter_proto_ConverterTest_descriptor,
-        new java.lang.String[] { "IntValue", "LongValue", "FloatValue", "DoubleValue", "BooleanValue", "StringValue", "PrimitiveValue", "FieldConversionValue", "NullDefaultValue", "StringListValue", "ComplexListValue", "ComplexSetValue", "ComplexNullableCollectionValue", "BytesValue", });
+        new java.lang.String[] { "IntValue", "LongValue", "FloatValue", "DoubleValue", "BooleanValue", "StringValue", "PrimitiveValue", "FieldConversionValue", "NullDefaultValue", "StringListValue", "ComplexListValue", "ComplexSetValue", "ComplexNullableCollectionValue", "BytesValue", "RecursiveValue", });
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/src/test/proto/converter_test.proto
+++ b/src/test/proto/converter_test.proto
@@ -39,4 +39,5 @@ message ConverterTest {
 	repeated PrimitiveTest complexListValue = 11;
 	repeated PrimitiveTest complexSetValue = 12;
 	repeated PrimitiveTest complexNullableCollectionValue = 13;
+	bytes bytesValue = 14;
 }

--- a/src/test/proto/converter_test.proto
+++ b/src/test/proto/converter_test.proto
@@ -40,4 +40,5 @@ message ConverterTest {
 	repeated PrimitiveTest complexSetValue = 12;
 	repeated PrimitiveTest complexNullableCollectionValue = 13;
 	bytes bytesValue = 14;
+	ConverterTest recursiveValue = 15;
 }


### PR DESCRIPTION
- fixed ProtobufWriter writeValue setter method not found issue when domain value type is a subclass of setter parameter type

  **Example**:

  when setting ByteString value to the protobuf from domain, if the domain use the subclass LiteralByteString, it will cause a 

  `net.badata.protobuf.converter.exception.WriteException: Setter not found: 'net.badata.protobuf.converter.proto.ConverterProto$ConverterTest$Builder.setBytesValue()'`

  becase the parameter value type of `setBytesValue` is ByteString.

- fixed DefaultmapperImpl stack overflow issue when parse recursive value 

  Recursive field is very useful for representing structures like trees. When the converter tries to convert a protobuf into the domain value, it attempts to create a new instance for the nested value. If the nested value has the same type as its parent, the converter will keep creating its nested values, eventually causes a `StackOverflowError`.